### PR TITLE
history uses OME.formatDate

### DIFF
--- a/omeroweb/webclient/templates/webclient/history/history_details.html
+++ b/omeroweb/webclient/templates/webclient/history/history_details.html
@@ -58,6 +58,10 @@
                 'delay': 300,
                 'loader': 'span.loading'
             });
+            
+            $('[data-isodate]').each(function() {
+            	$(this).text(OME.formatDate($(this).data('isodate')));
+        	});
         });
     </script>
     
@@ -98,7 +102,7 @@
                         <input type="checkbox" name="project" id="{{ c.id }}" class="hide">      
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
-                    <td class="date">{{ c.getDate }}</td>
+                    <td class="date" data-isodate='{{ c.getDate|date:"r" }}'></td>
                     <td><a href="{% url 'webindex' %}?show=project-{{ c.id }}" title="{% trans 'Show in hierarchy view' %}">
                         {% trans "Browse" %}
                     </a></td>
@@ -111,7 +115,7 @@
                         <input type="checkbox" name="screen" id="{{ c.id }}" class="hide">      
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
-                    <td class="date">{{ c.getDate }}</td>
+                    <td class="date" data-isodate='{{ c.getDate|date:"r" }}'></td>
                     <td><a href="{% url 'webindex' %}?show=screen-{{ c.id }}" title="{% trans 'Show in hierarchy view' %}">
                         {% trans "Browse" %}
                     </a></td>
@@ -124,7 +128,7 @@
                         <input type="checkbox" name="dataset" id="{{ c.id }}" class="hide">      
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
-                    <td class="date">{{ c.getDate }}</td>
+                    <td class="date" data-isodate='{{ c.getDate|date:"r" }}'></td>
                     <td><a href="{% url 'webindex' %}?show=dataset-{{ c.id }}" title="{% trans 'Show in hierarchy view' %}">
                         {% trans "Browse" %}
                     </a></td>
@@ -137,7 +141,7 @@
                         <input type="checkbox" name="plate" id="{{ c.id }}" class="hide">      
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
-                    <td class="date">{{ c.getDate }}</td>
+                    <td class="date" data-isodate='{{ c.getDate|date:"r" }}'></td>
                     <td><a href="{% url 'webindex' %}?show=plate-{{ c.id }}" title="{% trans 'Show in hierarchy view' %}">
                         {% trans "Browse" %}
                     </a></td>
@@ -152,7 +156,7 @@
                         <input type="checkbox" name="image" id="{{ c.id }}" class="hide">      
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
-                    <td class="date">{{ c.getDate }}</td>
+                    <td class="date" data-isodate='{{ c.getDate|date:"r" }}'></td>
                     <td><a href="{% url 'webindex' %}?show=image-{{ c.id }}" title="{% trans 'Show in hierarchy view' %}">
                         {% trans "Browse" %}
                     </a></td>


### PR DESCRIPTION
Hi Will- 
The other place dates are displayed is when someone clicks on the History tab.  In fact, this is where I originally came across this issue. I took a page out of your approach to the right hand panel date format and copied it to the history_details.html. Now the middle panel date column uses OME.formatDate under the history tab, and is consistent with dates in the right hand panel.
Because the dates only change when I change the timezone of my machine, and don't when I change the omero.web.time_zone configuration setting, I wonder what this setting actually does?
I'm still investigating the behaviour of the calendar itself, in the left panel. There is something not quite right. Datasets that I create after 5PM in America/Edmonton (i.e. they are tomorrow's date in the Europe/London timezone) appear on the correct day in the calendar (the folder icon is placed on the correct day), but clicking on that day gets me a "NoData" in the middle panel. I have to click on the next day (where the icon isn't placed) to see the dataset appear in the middle panel. I guess the date information in the calendar display and  controller/history.py needs to be examined. 