### PR TITLE
Make external info display generic and add templating blocks for customization

### DIFF
--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -206,7 +206,6 @@ class BaseContainer(BaseController):
             "lsid": extinfo.lsid,
             "entityType": extinfo.entityType,
             "entityId": extinfo.entityId,
-            "is_zarr": extinfo.entityType == "com.glencoesoftware.ngff:multiscales",
         }
 
     def getWellSampleImage(self):

--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -383,13 +383,17 @@
 
     <!-- External Info -->
     {% with extinfo=manager.external_info %}
+      {% block extinfo_button %}
       {% if extinfo %}
         <button id="show_ext_info" class="btn silver btn_extinfo" title="External Info" >
           <span style="margin: 3px 2px 1px 2px; background: transparent; box-shadow: none; font-size: 11px; padding: 0px;">
+          {% block extinfo_button_title %}
             Ext&nbsp;Info
+          {% endblock extinfo_button_title %}
           </span>
         </button>
       {% endif %}
+      {% endblock extinfo_button %}
     {% endwith %}
 
 
@@ -443,20 +447,27 @@
 <!-- This is hidden initially -->
 <div id="externalInfo" style="display: none; margin-top: 15px; font-size: 13px;">
 {% with extinfo=manager.external_info %}
+  {% block extinfo %}
   {% if extinfo %}
-
     <div style="background: white; padding: 7px; border: 1px solid rgb(221, 221, 221); overflow: auto; border-radius: 4px;">
       <h3>External Info</h3>
-      <div style="margin: 8px 0; word-wrap: break-word"><strong>{{ extinfo.lsid }}</strong></div>
+      <div style="margin: 8px 0; word-wrap: break-word"><strong>
+        {% block extinfo_lsid %}
+          {{ extinfo.lsid }}
+        {% endblock extinfo_lsid %}
+      </strong></div>
       <details>
         <summary>Details</summary>
-        <ul style="margin: 5px">
-          <li>externalInfo ID: <strong>{{ extinfo.id }}</strong></li>
-          <li>entityType: <strong>{{ extinfo.entityType }}</strong></li>
-          <li>entityId: <strong>{{ extinfo.entityId }}</strong></li>
-        </ul>
+        {% block extinfo_details %}
+          <ul style="margin: 5px">
+            <li>externalInfo ID: <strong>{{ extinfo.id }}</strong></li>
+            <li>entityType: <strong>{{ extinfo.entityType }}</strong></li>
+            <li>entityId: <strong>{{ extinfo.entityId }}</strong></li>
+          </ul>
+        {% endblock extinfo_details %}
       </details>
     </div>
   {% endif %}
+  {% endblock extinfo %}
 {% endwith %}
 </div>

--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -381,17 +381,16 @@
     {% endif %}
     {% endif %}
 
-    <!-- External Info (Zarr url)-->
+    <!-- External Info -->
     {% with extinfo=manager.external_info %}
-      {% if extinfo and extinfo.is_zarr %}
-        <button id="show_ext_info" class="btn silver btn_extinfo" title="Zarr url" >
-          <span style="width: 25px; margin: 3px 2px 1px 2px; background: transparent; box-shadow: none; font-size: 11px; padding: 0px;">
-            Zarr
+      {% if extinfo %}
+        <button id="show_ext_info" class="btn silver btn_extinfo" title="External Info" >
+          <span style="margin: 3px 2px 1px 2px; background: transparent; box-shadow: none; font-size: 11px; padding: 0px;">
+            Ext&nbsp;Info
           </span>
         </button>
       {% endif %}
     {% endwith %}
-    
 
 
     <div style="position: absolute; left: 0">
@@ -447,7 +446,7 @@
   {% if extinfo %}
 
     <div style="background: white; padding: 7px; border: 1px solid rgb(221, 221, 221); overflow: auto; border-radius: 4px;">
-      <h3>OME-Zarr Info</h3>
+      <h3>External Info</h3>
       <div style="margin: 8px 0; word-wrap: break-word"><strong>{{ extinfo.lsid }}</strong></div>
       <details>
         <summary>Details</summary>


### PR DESCRIPTION
This PR removes ZARR specific code and adds templating blocks to allow for customization of the toolbar button and the info panel.

This approach allows for project and installation specific entity types to be handled easily without requiring further modification of OMERO.web.

@will-moore @sbesson

### Example customization

Add the following file at location `webclient/annotations/includes/toolbar.html` within a directory configured in `omero.web.template_dirs`.  It renames the external info button if the respective `entityType` is present.

```django
{% extends "webclient/annotations/includes/toolbar.html" %}

{% block extinfo_button_title %}
{% if extinfo.entityType == "com.glencoesoftware.ngff:multiscales" %}
  Zarr
{% else %}
  {{ block.super }}
{% endif %}
{% endblock %}
```